### PR TITLE
parse input as real numbers

### DIFF
--- a/webapp/src/assets/test-token-near.json
+++ b/webapp/src/assets/test-token-near.json
@@ -6,7 +6,7 @@
       "type": "Native token",
       "address": "",
       "symbol": "NEAR",
-      "decimals": 9,
+      "decimals": 24,
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/near/info/logo.png"
     },
     {
@@ -14,7 +14,7 @@
       "type": "NEP-21",
       "address": "gold.nearswap.testnet",
       "symbol": "GOLD",
-      "decimals": 9,
+      "decimals": 24,
       "logoURI": ""
     },
     {
@@ -22,7 +22,7 @@
       "type": "NEP-21",
       "address": "usd.nearswap.testnet",
       "symbol": "USD",
-      "decimals": 9,
+      "decimals": 24,
       "logoURI": ""
     },
     {
@@ -30,7 +30,7 @@
       "type": "NEP-21",
       "address": "bat.nearswap.testnet",
       "symbol": "nBAT",
-      "decimals": 9,
+      "decimals": 24,
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0D8775F648430679A709E98d2b0Cb6250d2887EF/logo.png"
     },
     {
@@ -38,7 +38,7 @@
       "type": "NEP-21",
       "address": "mint_with_json-workaround-for-mintablefuntoken.chad",
       "symbol": "nABND",
-      "decimals": 9,
+      "decimals": 24,
       "logoURI": ""
     },
     {
@@ -46,7 +46,7 @@
       "type": "NEP-21",
       "address": "usd24.nearswap.testnet",
       "symbol": "USD24",
-      "decimals": 9,
+      "decimals": 24,
       "logoURI": ""
     }
   ]

--- a/webapp/src/assets/test-token-near.json
+++ b/webapp/src/assets/test-token-near.json
@@ -37,7 +37,15 @@
       "name": "Abundance Token",
       "type": "NEP-21",
       "address": "mint_with_json-workaround-for-mintablefuntoken.chad",
-      "symbol": "nABD",
+      "symbol": "nABND",
+      "decimals": 9,
+      "logoURI": ""
+    },
+    {
+      "name": "USD24 Token",
+      "type": "NEP-21",
+      "address": "usd24.nearswap.testnet",
+      "symbol": "USD24",
       "decimals": 9,
       "logoURI": ""
     }

--- a/webapp/tests/near-nep21-util.test.js
+++ b/webapp/tests/near-nep21-util.test.js
@@ -1,4 +1,4 @@
-import { normalizeAmount, trimZeros } from '../src/services/near-nep21-util'
+import { normalizeAmount, trimZeros, convertToReal } from '../src/services/near-nep21-util'
 import { assert } from "chai";
 
 describe("Normalize Accounts ", () => {
@@ -29,5 +29,22 @@ describe("Normalize Accounts ", () => {
 
         var res = normalizeAmount("42");
         assert.equal(res, "42000000000000000000000000", 'mismatch');
+    });
+});
+
+describe("Convert to real number", () => {
+
+    it("Division ",  () => {
+        var res = convertToReal("1000000000000000000000000");
+        assert.equal(res, "1", 'mismatch');
+        
+        var res = convertToReal("10000000000000000000000");
+        assert.equal(res, "0.01", 'mismatch');
+
+        var res = convertToReal("1234567891234567891234567");
+        assert.equal(res, "1.234567891234567891234567", 'mismatch');
+
+        var res = convertToReal("1234567891234567894567");
+        assert.equal(res, "0.001234567891234567894567", 'mismatch');
     });
 });

--- a/webapp/tests/near-nep21-util.test.js
+++ b/webapp/tests/near-nep21-util.test.js
@@ -1,4 +1,4 @@
-import { normalizeAmount, trimZeros, convertToReal } from '../src/services/near-nep21-util'
+import { normalizeAmount, trimZeros, convertToE24Base } from '../src/services/near-nep21-util'
 import { assert } from "chai";
 
 describe("Normalize Accounts ", () => {
@@ -21,6 +21,15 @@ describe("Normalize Accounts ", () => {
 
         res = trimZeros("0020");
         assert.equal(res, "20", 'mismatch');
+
+        res = trimZeros("0.0");
+        assert.equal(res, "0", 'mismatch');
+
+        res = trimZeros("000.00000");
+        assert.equal(res, "0", 'mismatch');
+
+        res = trimZeros("00");
+        assert.equal(res, "0", 'mismatch');
     });
 
     it("normalize accounts ", () => {
@@ -35,16 +44,31 @@ describe("Normalize Accounts ", () => {
 describe("Convert to real number", () => {
 
     it("Division ",  () => {
-        var res = convertToReal("1000000000000000000000000");
+        var res = convertToE24Base("1000000000000000000000000");
         assert.equal(res, "1", 'mismatch');
         
-        var res = convertToReal("10000000000000000000000");
+        var res = convertToE24Base("10000000000000000000000");
         assert.equal(res, "0.01", 'mismatch');
 
-        var res = convertToReal("1234567891234567891234567");
+        var res = convertToE24Base("1234567891234567891234567");
         assert.equal(res, "1.234567891234567891234567", 'mismatch');
 
-        var res = convertToReal("1234567891234567894567");
+        var res = convertToE24Base("1234567891234567894567");
         assert.equal(res, "0.001234567891234567894567", 'mismatch');
+
+        var res = convertToE24Base("1");
+        assert.equal(res, "0.000000000000000000000001", 'mismatch');
+
+        var res = convertToE24Base("0");
+        assert.equal(res, "0", 'mismatch');
+
+        var res = convertToE24Base("00");
+        assert.equal(res, "0", 'mismatch');
+
+        var res = convertToE24Base("0012340000000000000000000000000");
+        assert.equal(res, "12340", 'mismatch');
+
+        var res = convertToE24Base("0012340000000000000000000000001");
+        assert.equal(res, "12340.000000000000000000000001", 'mismatch');
     });
 });


### PR DESCRIPTION
- Parse all inputs as real numbers with 24 decimals

- Present all outputs as real numbers assuming 24 decimals

- “current allowance” should be displayed assuming 24 digits

- change approval “fee” to 0.04 (during call)

** I have tested parsing using tests but not on testnet as i was getting pool doesn't exist(for USD24) , Please merge it when it is tested on testnet